### PR TITLE
added flash compatibility

### DIFF
--- a/from_blender.sh
+++ b/from_blender.sh
@@ -6,10 +6,13 @@ fx_dir=$3 # directory with Brainder conversion functions (3rd input parameter)
 
 echo "Processing subject: ${subj}"
 
-dir_bem=${subj_dir}/${subj}/bem/watershed
-dir_conv=${dir_bem}/conv
+dir_bem=${subj_dir}/${subj}/bem
+dir_surf=${subj_dir}/${subj}/surf
+dir_conv=${subj_dir}/${subj}/conv
 
 surfs=(brain inner_skull outer_skull outer_skin)
+seg_surfs=(seghead)
+hemis=(lh rh)
 
 for s in "${surfs[@]}"
 do
@@ -24,6 +27,22 @@ do
 		# copy the new surface to the watershed folder and rename as the original
 		# cp ${dir_conv}/${surf_edit} ${dir_bem}/${surf_ori}
 	fi
+done
+
+for hemi in "${hemis[@]}"
+do
+    for s in "${seg_surfs[@]}"
+    do
+    	surf_edit=${hemi}.${s}.edit
+
+        if [ -f "${dir_surf}/${hemi}.${s}" ]; then
+            echo "Converting file ${surf_edit}"
+			${fx_dir}/obj2srf ${dir_conv}/${surf_edit}.obj > ${dir_conv}/${surf_edit}.asc  # convert to ascii
+			mris_convert ${dir_conv}/${surf_edit}.asc ${dir_conv}/${surf_edit} # convert to freesurfer surface
+        fi
+    
+    done
+
 done
 
 

--- a/to_blender.sh
+++ b/to_blender.sh
@@ -6,7 +6,7 @@ fx_dir=$3 # directory with Brainder conversion functions (3rd input parameter)
 
 echo "Processing subject: ${subj}"
 
-dir_bem=${subj_dir}/${subj}/bem/watershed
+dir_bem=${subj_dir}/${subj}/bem
 dir_conv=${dir_bem}/conv
 
 if [ ! -d "$dir_conv" ]; then
@@ -17,11 +17,23 @@ surfs=(brain inner_skull outer_skull outer_skin)
 
 for s in "${surfs[@]}"
 do
-	surf_ori=${subj}_${s}_surface
-	surf_bkup=${dir_conv}/${surf_ori}_bkup
+        if [ -f "${dir_bem}/watershed/${subj}_${s}_surface" ]; then
+            dir_ori=watershed
+            surf_ori=${subj}_${s}_surface
+        elif [ -f "${dir_bem}/flash/${s}.surf" ]; then
+            dir_ori=flash
+            surf_ori=${s}.surf
+        else
+            echo "No water shed or flash file found for: ${s} "
+            echo "under ${dir_bem}/watershed/${subj}_${s}_surface "
+            echo "or ${dir_bem}/flash/${s}.surf" 
+            continue
+        fi
+        surf_bkup=${dir_conv}/${surf_ori}_bkup
+	
 
 	if [ ! -f "$surf_bkup" ]; then
-	  cp ${dir_bem}/${surf_ori} ${surf_bkup} # make backup file if it doesn't exist
+	  cp ${dir_bem}/${dir_ori}/${surf_ori} ${surf_bkup} # make backup file if it doesn't exist
 	fi
 
 	mris_convert ${surf_bkup} ${dir_conv}/${surf_ori}.asc   # convert to ascii

--- a/to_blender.sh
+++ b/to_blender.sh
@@ -7,13 +7,17 @@ fx_dir=$3 # directory with Brainder conversion functions (3rd input parameter)
 echo "Processing subject: ${subj}"
 
 dir_bem=${subj_dir}/${subj}/bem
-dir_conv=${dir_bem}/conv
+dir_surf=${subj_dir}/${subj}/surf
+dir_conv=${subj_dir}/${subj}/conv
 
 if [ ! -d "$dir_conv" ]; then
   mkdir ${dir_conv}
 fi
 
 surfs=(brain inner_skull outer_skull outer_skin)
+seg_surfs=(seghead)
+hemis=(lh rh)
+
 
 for s in "${surfs[@]}"
 do
@@ -24,7 +28,7 @@ do
             dir_ori=flash
             surf_ori=${s}.surf
         else
-            echo "No water shed or flash file found for: ${s} "
+            echo "No watershed or flash file found for: ${s} "
             echo "under ${dir_bem}/watershed/${subj}_${s}_surface "
             echo "or ${dir_bem}/flash/${s}.surf" 
             continue
@@ -38,8 +42,33 @@ do
 
 	mris_convert ${surf_bkup} ${dir_conv}/${surf_ori}.asc   # convert to ascii
 	${fx_dir}/srf2obj ${dir_conv}/${surf_ori}.asc > ${dir_conv}/${surf_ori}.obj # convert to .obj
+
 done
 
+
+for hemi in "${hemis[@]}"
+do
+    for s in "${seg_surfs[@]}"
+    do
+        if [ -f "${dir_surf}/${hemi}.${s}" ]; then
+            surf_ori=${hemi}.${s}
+        else
+            echo "No surface file found for: ${hemi}.${s} "
+            continue
+        fi
+        surf_bkup=${dir_conv}/${surf_ori}_bkup
+    
+
+        if [ ! -f "$surf_bkup" ]; then
+          cp ${dir_surf}/${surf_ori} ${surf_bkup} # make backup file if it doesn't exist
+        fi
+
+        mris_convert ${surf_bkup} ${dir_conv}/${surf_ori}.asc   # convert to ascii
+        ${fx_dir}/srf2obj ${dir_conv}/${surf_ori}.asc > ${dir_conv}/${surf_ori}.obj # convert to .obj
+    
+    done
+
+done
 # -> EDIT IN BLENDER
 
 


### PR DESCRIPTION
It is possible but unlikely for flash scans to have overlapping BEM errors, but more likely this would be used to put noisy outer_skin reconstructions into blender for editing so that data visualizations that use the outer_skin will look better. See for instance the sample MNE outer skin in MMVT visualizations in the README here: https://github.com/alexrockhill/MEEGbuddy.